### PR TITLE
Updated workflow and example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
     name: Checkout and upload Readme to Notion
     steps:
       - name: checkout
-        uses: "actions/checkout@v3.0.2"
+        uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"
       - name: Upload to Notion
-        uses: agonzalezl/readme-to-notion-action@v1
+        uses: agonzalezl/readme-to-notion-action@88b6cb8eea354ac61c589f540e40cacadf0c8ecb
         with:
           static-top-text: '_This documentation is self-generated and will be overwritten. Please do not edit it manually._'
           static-bottom-text: '_This documentation is self-generated and will be overwritten. Please do not edit it manually._'

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Static content added after the Markdown content
 
 
 # Example usage
-Set in your GitHub repository Settings > Secrets (Actions) a secret `NOTION_TOKEN` with your Integration Token from Notion and `NOTION_PAGE_ID` with the id of your Notion Page. Don't forget to give your token [access to the page.](https://github.com/agonzalezl/test-github-actions#give-your-notion-integration-token-access-to-your-page)
+Set in your GitHub repository Settings > Secrets (Actions) a secret `NOTION_TOKEN` with your Integration Token from Notion and `NOTION_PAGE_ID` with the id of your Notion Page. Don't forget to give your token [access to the page.](https://github.com/agonzalezl/test-github-actions#give-your-notion-integration-token-access-to-your-page).
+
+Create the file `.github/workflows/main.yml` with the following content:
 ```yml
 name: Main Workflow
 
@@ -32,7 +34,7 @@ on:
     branches:
       - 'master'
     paths:
-      - 'README.md'
+      - './README.md'
 
 jobs:
   hello_world_job:
@@ -40,17 +42,18 @@ jobs:
     name: Checkout and upload Readme to Notion
     steps:
       - name: checkout
-        uses: "actions/checkout@v3.0.2"
+        uses: "actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b"
       - name: Upload to Notion
-        id: hello
-        uses: agonzalezl/test-github-actions@master
+        uses: agonzalezl/readme-to-notion-action@88b6cb8eea354ac61c589f540e40cacadf0c8ecb
         with:
           static-top-text: '_This documentation is self-generated and will be overwritten. Please do not edit it manually._'
           static-bottom-text: '_This documentation is self-generated and will be overwritten. Please do not edit it manually._'
           file-path: './README.md'
           notion-token: ${{ secrets.NOTION_TOKEN }}
           notion-page-id: ${{ secrets.NOTION_PAGE_ID }}
+
 ```
+Read more [here](https://julienrenaux.fr/2019/12/20/github-actions-security-risk/) about why to use commit hash instead of version in Github actions.
 
 ## Give your Notion Integration token access to your page
 After creating a token in [my-integrations](https://www.notion.so/my-integrations), in your Notion page click `Share`, click in the `invite` search box and search for the name of your integration.


### PR DESCRIPTION
Following this recomendation https://julienrenaux.fr/2019/12/20/github-actions-security-risk/ using commit hash as reference of the version of the action instead of an actual reference.